### PR TITLE
Fix: OAD Support for CC13xx

### DIFF
--- a/src/components/FWUpdate/FWUpdate_Modal.tsx
+++ b/src/components/FWUpdate/FWUpdate_Modal.tsx
@@ -1104,7 +1104,7 @@ const FWUpdate_Modal: React.FC<Props> = ({ peripheralId }: any) => {
     if (hexMagicNumber === '3db8f396' || hexMagicNumber === '3db8f397') {
       return 'mcuboot';
     }
-    else if (hexMagicNumber === '43433236') {
+    else if (hexMagicNumber === '43433236' || hexMagicNumber === '43433136') {
       return 'bim';
     }
     else {

--- a/src/components/FWUpdate/FWUpdate_Modal.tsx
+++ b/src/components/FWUpdate/FWUpdate_Modal.tsx
@@ -1104,7 +1104,7 @@ const FWUpdate_Modal: React.FC<Props> = ({ peripheralId }: any) => {
     if (hexMagicNumber === '3db8f396' || hexMagicNumber === '3db8f397') {
       return 'mcuboot';
     }
-    else if (hexMagicNumber === '43433236' || hexMagicNumber === '43433136') {
+    else if (hexMagicNumber === '43433236' || hexMagicNumber === '43433133') {
       return 'bim';
     }
     else {


### PR DESCRIPTION
CC1352 also supports bluetooth and OAD updates.

Simplelink Connect is curretly rejecting CC13xx binaries.

With this change, binaries compiled for CC26xx and CC13xx will be accepted.